### PR TITLE
Build WITH_AUTHENTICATION_CLIENT_PLUGINS=ON

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -28,6 +28,9 @@ cmake -S%SRC_DIR% -Bbuild -GNinja ^
   -DLIBEVENT_OPENSSL=%libevent_openssl_lib% ^
   -DWITH_ICU=system ^
   -DWITH_PROTOBUF=system ^
+  -DWITH_KERBEROS=none ^
+  -DWITH_FIDO=none ^
+  -DWITH_SASL=none ^
   -DPROTOBUF_INCLUDE_DIR=%LIBRARY_PREFIX%\include ^
   -DDEFAULT_CHARSET=utf8 ^
   -DDEFAULT_COLLATION=utf8_general_ci ^
@@ -38,7 +41,8 @@ cmake -S%SRC_DIR% -Bbuild -GNinja ^
   -DINSTALL_INFODIR=share/info ^
   -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
   -DINSTALL_MYSQLSHAREDIR=share/mysql ^
-  -DINSTALL_SUPPORTFILESDIR=mysql/support-files
+  -DINSTALL_SUPPORTFILESDIR=mysql/support-files ^
+  -DWITH_AUTHENTICATION_CLIENT_PLUGINS=ON
 if %ERRORLEVEL% neq 0 exit 1
 
 cmake --build build --config Release

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -116,6 +116,9 @@ cmake -S$SRC_DIR -Bbuild -GNinja \
   -DWITH_ICU=system \
   -DWITH_EDITLINE=system \
   -DWITH_PROTOBUF=system \
+  -DWITH_KERBEROS=none \
+  -DWITH_FIDO=none \
+  -DWITH_SASL=none \
   -DPROTOBUF_INCLUDE_DIR=${PREFIX}/include \
   -DDEFAULT_CHARSET=utf8 \
   -DDEFAULT_COLLATION=utf8_general_ci \
@@ -127,6 +130,7 @@ cmake -S$SRC_DIR -Bbuild -GNinja \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
   -DINSTALL_MYSQLSHAREDIR=share/mysql \
   -DINSTALL_SUPPORTFILESDIR=mysql/support-files \
+  -DWITH_AUTHENTICATION_CLIENT_PLUGINS=ON \
   "${_xtra_cmake_args[@]}"
 
 if [[ $target_platform == osx-arm64 ]] && [[ $CONDA_BUILD_CROSS_COMPILATION == 1 ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,9 +31,10 @@ source:
     - patches/0020-Use-config-mode-search-for-protobuf-first.patch
     - patches/0021-Simplify-protobuf-deps-using-cmake-alias.patch
     - patches/0022-Set-PROTOBUF_INCLUDE_DIR-only-if-not-set.patch
+    - patches/0023-Allow-setting-WITH_SASL-none.patch
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:
@@ -124,6 +125,8 @@ outputs:
       commands:
         - mysql --version
         - mysqldump --version
+        - test -f ${PREFIX}/lib/plugin/mysql_native_password.so  # [unix]
+        - if not exist %LIBRARY_LIB%\plugin\mysql_native_password.dll exit 1  # [win]
     about:
       license_file: LICENSE
       license: GPL-2.0-or-later

--- a/recipe/patches/0023-Allow-setting-WITH_SASL-none.patch
+++ b/recipe/patches/0023-Allow-setting-WITH_SASL-none.patch
@@ -1,0 +1,26 @@
+From e5f3b6115c4f87edec62875a01a7585ee4eec276 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Tue, 1 Apr 2025 23:14:29 +0100
+Subject: [PATCH 23/23] Allow setting WITH_SASL=none
+
+---
+ cmake/sasl.cmake | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/cmake/sasl.cmake b/cmake/sasl.cmake
+index d814c756d11..137c9376d45 100644
+--- a/cmake/sasl.cmake
++++ b/cmake/sasl.cmake
+@@ -266,6 +266,9 @@ MACRO(MYSQL_CHECK_SASL)
+     ELSE()
+       MESSAGE(FATAL_ERROR "-DWITH_SASL=<path> not supported on this platform")
+     ENDIF()
++  ELSEIF(WITH_SASL STREQUAL "none")
++    SET(SASL_FOUND FALSE)
++    MESSAGE(STATUS "SASL path is none, disabling sasl support.")
+   ELSE()
+     RESET_SASL_VARIABLES()
+     MESSAGE(FATAL_ERROR "Could not find SASL")
+-- 
+2.33.1
+


### PR DESCRIPTION
But build only the mysql_native_password for now

Resolves https://github.com/conda-forge/mysql-feedstock/issues/106

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
